### PR TITLE
POP-1983: fix for crashlytics crash where client is closed

### DIFF
--- a/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -803,6 +803,7 @@ public class AWSIotMqttManager {
                     connectionState = MqttManagerConnectionState.Disconnecting;
                     userConnectionCallback();
                     break;
+                case MqttException.REASON_CODE_CLIENT_CLOSED:
                 case MqttException.REASON_CODE_CONNECTION_LOST:
                     connectionState = MqttManagerConnectionState.Disconnected;
                     userConnectionCallback(e);


### PR DESCRIPTION
* treat previously unhandled client closed state as connection lost